### PR TITLE
add foreman to start the app with Procfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,4 @@ gem 'unicorn'
 gem 'pg'
 
 gem 'zero_push'
+gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    dotenv (0.11.1)
+      dotenv-deployment (~> 0.0.2)
+    dotenv-deployment (0.0.2)
     faraday (0.8.9)
       multipart-post (~> 1.2.0)
     faraday_middleware (0.9.0)
       faraday (>= 0.7.4, < 0.9)
+    foreman (0.74.0)
+      dotenv (~> 0.11.1)
+      thor (~> 0.19.1)
     json (1.8.1)
     kgio (2.9.2)
     mime-types (2.2)
@@ -26,6 +32,7 @@ GEM
     sinatra-sequel (0.9.0)
       sequel (>= 3.2.0)
       sinatra (>= 0.9.4)
+    thor (0.19.1)
     tilt (1.4.1)
     unicorn (4.8.2)
       kgio (~> 2.6)
@@ -39,6 +46,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  foreman
   json
   pg
   rest-client

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The server is designed to run with a [Postgres](https://devcenter.heroku.com/art
 - `$ cp dotenv.sample .env`
 - `$ gem install bundler; bundle install`
 
+To run the server locally run `foreman start`
+
 #### Images
 Put your people images in the public folder and name them the same as the names used in the app.
 


### PR DESCRIPTION
This way the app is started with the same Procfile that is used on Heroku when ran locally, I figured it would be convenient for people to have foreman automatically installed as a dependency.
