### PR TITLE
Update css to properly truncate long names

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -32,7 +32,6 @@ td {
 	padding: 2px 5px 2px 10px;
 	white-space: nowrap;
 	overflow: hidden;
-	text-overflow: ellipsis;
 	line-height: 23px;
 }
 
@@ -47,13 +46,13 @@ td {
 
 .name
 {
-	float: left;
 	clear: none;
-/* 	width: 80%; */
 	color: white;
 	margin-top: 5px;
-	margin-left: 12px;
+	margin-left: 62px;
 	text-transform: uppercase;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 .status
 {


### PR DESCRIPTION
Long names weren't properly truncating on small screens (Status Board). This CSS tweak fixes that.

Before:
![before](https://cloud.githubusercontent.com/assets/125/3574377/6c3a840c-0b7d-11e4-8f26-4eb83450cfd9.png)

After:
![after](https://cloud.githubusercontent.com/assets/125/3574295/9ce6d034-0b7c-11e4-91f9-2a91a76289cb.png)
