### PR TITLE
fix app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,6 +21,6 @@
   },
   "addons": [
     "zeropush",
-    "heroku-postgresql:dev"
+    "heroku-postgresql"
   ]
 }


### PR DESCRIPTION
heroku postgresql:basic is not the correct addon name
