### PR TITLE
updated addons to reflect name change of heroku-postgresql

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,6 +21,6 @@
   },
   "addons": [
     "zeropush",
-    "heroku-postgresql:dev"
+    "heroku-postgresql"
   ]
 }


### PR DESCRIPTION
I was getting an error when deploying to heroku and it looks like it's because the addon for Hobby Dev (the free one) is now called just heroku-postgresql
