### PR TITLE
Use push_id to allow name changes in many cases

### DIFF
--- a/my_app.rb
+++ b/my_app.rb
@@ -96,7 +96,13 @@ post '/status/update' do
     lowName = params[:name].downcase
     lowName = 'steven' if lowName == 'stevenf'
 
-    person = Person.for_update.first(:name => lowName)
+    if params[:push_id] && !params[:push_id].empty?
+      person = Person.for_update.first(:push_id => params[:push_id])
+    end
+
+    if !person
+      person = Person.for_update.first(:name => lowName)
+    end
 
     if !person
       person = Person.new()


### PR DESCRIPTION
People have a tendency to change their name (especially when first using the app) which leads to duplicates. I realized the `push_id` will usually come through the same, so I first look for that to update, then fall back to the normal flow. 

This will currently error if you use someone else's name, but in our experience, that's less likely to happen than people changing their name.